### PR TITLE
Changing connect setup in readme

### DIFF
--- a/day3/README.md
+++ b/day3/README.md
@@ -116,16 +116,20 @@ Enough information, time to code!
 ### Task 1: Make a component that calls a `GAME_RESET` action
 We start by implementing the Reset button (as shown in the introduction). 
 Our first goal with Redux will be to make a button that trigger's the `GAME_RESET` action in the Redux debug panel.
-Create a React component `ResetGame`, consisting of a button element with an onClick-handler that dispatches the `resetGame()` action creator (`src/actions.js`).
-Remember to `connect` the component when exporting it, like so:
+Create a React component `ResetGame` (`src/components/ResetGame.js`), consisting of a button element with an onClick-handler that triggers a function passed through the `props`.
+Insert the new component into the `Game` component. Remember to import it at the top of the file. 
+
+The onClick function that is passed from the `Game` parent should dispatch the `resetGame()` action creator (`src/actions.js`).
+First, `connect` the `Game` component when exporting it, like so:
 ```
-export default connect()(ResetGame);
+export default connect()(Game);
 ```
-Once the component is connected, the `dispatch` function is automatically available as a prop.
+Once the component is connected, the `dispatch` function is automatically available as a prop. 
 ```
-props.dispatch(resetGame())
+<ResetGame onButtonClick ={props.dispatch(resetGame())}/>
 ```
-Insert the new component `ResetGame` into the `Game` component. Remember to import it at the top of the file.
+We have already imported the `resetGame` action for you at the top of `src/components/Game.js`.
+
 Open the game in the browser and press your newly created button, an action should be firing in the debug panel on the right side!
 
 ### Task 2: Turning static data into dynamic data - implement your first reducer

--- a/day3/README.md
+++ b/day3/README.md
@@ -126,7 +126,7 @@ export default connect()(Game);
 ```
 Once the component is connected, the `dispatch` function is automatically available as a prop. 
 ```
-<ResetGame onButtonClick ={props.dispatch(resetGame())}/>
+<ResetGame onButtonClick ={ () => props.dispatch(resetGame()) }/>
 ```
 We have already imported the `resetGame` action for you at the top of `src/components/Game.js`.
 

--- a/day3/README.md
+++ b/day3/README.md
@@ -192,15 +192,18 @@ export default connect(state => ({
 ```
 Thus, all you need to do is to pass `props.cards` to the `Game` component. Now, when you press the Restart button, all cards should flip!
     
-### Task 3: Sending an onClick handler from the Game component to the Card component - passing functions down the hierarchy
-Guro write here
-    
-### Task 4: Flip a single card - practicing the Redux pattern 
+### Task 3: Flip a single card - practicing the Redux pattern 
 Start by creating a new action creator `flipCard(card)` that returns an object with the type `CARD_FLIP` in `actions.js`. 
 Remember to export the action type constant at the top of the file.
 In the action returned by `flipCard` you also need to send the card data, so that the reducer "knows" which card to flip.
-Next, call this action creator when you click on a card (Hint: see `ResetGame`), remember to import the `connect` function. 
-Check the Redux panel to see if the action is firing.
+
+### Task 4: Sending an onClick handler from the Game component to the Card component - passing functions down the hierarchy
+Now, we need to dispatch the `flipCard` action creator when you click on a card.
+In Task 1 we connected the `Game` component, which gave us access to the `dispatch` function. 
+Thus, in the Game component, we can can create a callback function that dispatches `flipCard`, and pass this callback down to the `Card` component.
+(Hint: see ResetGame.js, the only difference here is that we need to pass the callback through the `Board` component, as the `Card`component is not a direct child of `Game`.)
+Check the Redux panel to see if the action is firing when you click on a card.
+
 Lastly, implement the corresponding reducer, i.e. expand the switch statement that you created in `reducers.js`. 
 When you have finished this task, cards should open when you click on them. 
 

--- a/day3/README.md
+++ b/day3/README.md
@@ -116,10 +116,10 @@ Enough information, time to code!
 ### Task 1: Make a component that calls a `GAME_RESET` action
 We start by implementing the Reset button (as shown in the introduction). 
 Our first goal with Redux will be to make a button that trigger's the `GAME_RESET` action in the Redux debug panel.
-Create a React component `ResetGame` (`src/components/ResetGame.js`), consisting of a button element with an onClick-handler that triggers a function passed through the `props`.
+Create a React component `ResetGame` (`src/components/ResetGame.js`), consisting of a button element with an onClick-handler that calls a function passed through the `props`.
 Insert the new component into the `Game` component. Remember to import it at the top of the file. 
 
-The onClick function that is passed from the `Game` parent should dispatch the `resetGame()` action creator (`src/actions.js`).
+The onClick callback that is passed from the `Game` parent should dispatch the `resetGame()` action creator (`src/actions.js`).
 First, `connect` the `Game` component when exporting it, like so:
 ```
 export default connect()(Game);

--- a/day3/src/components/Game.js
+++ b/day3/src/components/Game.js
@@ -3,6 +3,9 @@ import React from 'react';
 import Score from './Score';
 import Highscore from './Highscore';
 import Board from './Board';
+import {
+    resetGame
+} from '../actions';
 
 const Game = ( props ) => {
   return (


### PR DESCRIPTION
Changed the task text so that we do not connect the card and the reset game component, instead the students will connect the Game component and pass callbacks to the onClick-handlers of the child components. 
